### PR TITLE
Add attr_accessible :preferred_api_key for Rails 3.2.x

### DIFF
--- a/app/models/spree/komoju_gateway.rb
+++ b/app/models/spree/komoju_gateway.rb
@@ -2,6 +2,8 @@ module Spree
   class KomojuGateway < Gateway
     preference :api_key, :string
 
+    attr_accessible :preferred_api_key
+
     def provider_class
       ActiveMerchant::Billing::KomojuGateway
     end


### PR DESCRIPTION
I'll merge it if passed tests.