### PR TITLE
Enable customer profiles

### DIFF
--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -6,7 +6,7 @@ module Spree
 
     def purchase(money, source, options)
       options = change_options_to_dollar(options) if options[:currency] == "JPY"
-      if profile_id = source.gateway_payment_profile_id
+      if profile_id = source.gateway_payment_profile_id || source.gateway_customer_profile_id
         payment_details = profile_id
       else
         payment_details = source.to_active_merchant
@@ -14,12 +14,17 @@ module Spree
       super(money - options[:tax], payment_details, options)
     end
 
+    # enable either token-based profiles or customer-based profiles
     def create_profile(payment)
-      if payment.source.gateway_customer_profile_id.nil? && payment.source.number.present?
-        response = provider.store(payment.source.to_active_merchant, options)
+      return unless payment.source.number.present?
+      profile_id_name = SpreeKomoju.enable_customer_profiles ? :gateway_customer_profile_id : :gateway_payment_profile_id
+      profile_id = payment.source.public_send(profile_id_name)
+      if profile_id.nil?
+        response = provider.store(payment.source.to_active_merchant,
+                                  options.merge(customer_profile: (profile_id_name == :gateway_customer_profile_id)))
 
         if response.success?
-          payment.source.update_attributes!(:gateway_payment_profile_id => response.params['id'])
+          payment.source.update_attributes!(profile_id_name => response.params['id'])
         else
           payment.send(:gateway_error, response.message)
         end

--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -18,19 +18,16 @@ module Spree
     def create_profile(payment)
       return unless payment.source.number.present?
 
-      options = {}
-
       if SpreeKomoju.enable_customer_profiles
         profile_id_name = :gateway_customer_profile_id
-        options = options.merge(email: payment.order.email)
+        options = { email: payment.order.email, customer_profile: true }
       else
         profile_id_name = :gateway_payment_profile_id
       end
 
       profile_id = payment.source.public_send(profile_id_name)
       if profile_id.nil?
-        response = provider.store(payment.source.to_active_merchant,
-                                  options.merge(customer_profile: (profile_id_name == :gateway_customer_profile_id)))
+        response = provider.store(payment.source.to_active_merchant, options)
 
         if response.success?
           payment.source.update_attributes!(profile_id_name => response.params['id'])

--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -17,7 +17,16 @@ module Spree
     # enable either token-based profiles or customer-based profiles
     def create_profile(payment)
       return unless payment.source.number.present?
-      profile_id_name = SpreeKomoju.enable_customer_profiles ? :gateway_customer_profile_id : :gateway_payment_profile_id
+
+      options = {}
+
+      if SpreeKomoju.enable_customer_profiles
+        profile_id_name = :gateway_customer_profile_id
+        options = options.merge(email: payment.order.email)
+      else
+        profile_id_name = :gateway_payment_profile_id
+      end
+
       profile_id = payment.source.public_send(profile_id_name)
       if profile_id.nil?
         response = provider.store(payment.source.to_active_merchant,

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -45,7 +45,11 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment_details(post, payment, options)
 
-        commit("/tokens", post)
+        if options[:customer_profile]
+          commit("/customers", post)
+        else
+          commit("/tokens", post)
+        end
       end
 
       private
@@ -63,10 +67,14 @@ module ActiveMerchant #:nodoc:
           details[:given_name] = payment.first_name
           details[:family_name] = payment.last_name
           details[:email] = options[:email] if options[:email]
-        else
-          details = payment
+          post[:payment_details] = details
+        when String
+          if payment.match(/^tok_/)
+            post[:payment_details] = payment
+          else
+            post[:customer] = payment
+          end
         end
-        post[:payment_details] = details
       end
 
       def add_fraud_details(post, options)

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -46,6 +46,7 @@ module ActiveMerchant #:nodoc:
         add_payment_details(post, payment, options)
 
         if options[:customer_profile]
+          post[:email] = options[:email]
           commit("/customers", post)
         else
           commit("/tokens", post)

--- a/lib/spree_komoju/engine.rb
+++ b/lib/spree_komoju/engine.rb
@@ -1,4 +1,6 @@
 module SpreeKomoju
+  mattr_accessor :enable_customer_profiles
+
   class Engine < Rails::Engine
     require 'spree/core'
     isolate_namespace Spree

--- a/spec/models/spree/gateway/komoju_credit_card_spec.rb
+++ b/spec/models/spree/gateway/komoju_credit_card_spec.rb
@@ -12,6 +12,7 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
     let(:money) { 1000.0 }
     let(:source) do
       double("credit card", gateway_payment_profile_id: payment_profile_id,
+                            gateway_customer_profile_id: nil,
                             to_active_merchant: details)
     end
     let(:currency) { "JPY" }
@@ -52,8 +53,8 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
     let(:payment) { double("payment", source: source) }
     let(:details) { double("payment details") }
 
-    context "source has credit card and no gateway_customer_profile_id" do
-      let(:source) { double("credit card", gateway_customer_profile_id: nil,
+    context "source has credit card and no gateway_payment_profile_id" do
+      let(:source) { double("credit card", gateway_payment_profile_id: nil,
                                            number: "4111111111111111",
                                            to_active_merchant: details) }
       before do
@@ -92,7 +93,7 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
     end
 
     context "source has no number" do
-      let(:source) { double("credit card", gateway_customer_profile_id: nil,
+      let(:source) { double("credit card", gateway_payment_profile_id: nil,
                                            number: nil,
                                            to_active_merchant: details) }
 
@@ -102,8 +103,8 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
       end
     end
 
-    context "source already has a customer profile id" do
-      let(:source) { double("credit card", gateway_customer_profile_id: "tok_123",
+    context "source already has a payment profile id" do
+      let(:source) { double("credit card", gateway_payment_profile_id: "tok_123",
                                            number: nil,
                                            to_active_merchant: details) }
 


### PR DESCRIPTION
This adds an option which can be enabled using `SpreeKomoju.enable_customer_profiles = true` to use customer profiles stored in `gateway_customer_profile_id` rather than one-time tokens.

It doesn't seem that there is any way to enable/disable this selectively through spree/activemerchant, since they use the same methods (`create_profile` and `store`, respectively) for storing cc details universally, either as tokens *or* as customers.

I haven't added specs for the customer feature yet since it's very experimental, but the existing specs continue to pass (I'll add travis in another PR so we can check this before merging anything in the future).