### PR TITLE
Default to empty payment options hash

### DIFF
--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -23,6 +23,7 @@ module Spree
         options = { email: payment.order.email, customer_profile: true }
       else
         profile_id_name = :gateway_payment_profile_id
+        options = {}
       end
 
       profile_id = payment.source.public_send(profile_id_name)

--- a/spec/models/spree/gateway/komoju_credit_card_spec.rb
+++ b/spec/models/spree/gateway/komoju_credit_card_spec.rb
@@ -59,7 +59,7 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
                                            to_active_merchant: details) }
       before do
         allow(response).to receive(:params).and_return("id" => "tok_123")
-        expect(komoju_gateway).to receive(:store).with(details, hash_including()) { response }
+        expect(komoju_gateway).to receive(:store).with(details, {}) { response }
       end
 
       context "response is success" do
@@ -73,7 +73,7 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
         end
 
         it "updates source with payment profile id" do
-          allow(komoju_gateway).to receive(:store).with(details, hash_including()) { response }
+          allow(komoju_gateway).to receive(:store).with(details, {}) { response }
           expect(source).to receive(:update_attributes!).with(gateway_payment_profile_id: "tok_123")
           subject.create_profile(payment)
         end


### PR DESCRIPTION
The spec was actually checking this, but I had assumed that `hash_including()` would check that the thing was actually a hash. Apparently it doesn't do anything...