### PR TITLE
Use payment hash if payment is not credit card or token

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -75,6 +75,8 @@ module ActiveMerchant #:nodoc:
           else
             post[:customer] = payment
           end
+        else
+          post[:payment_details] = payment
         end
       end
 


### PR DESCRIPTION
Now that we've added support for customer profiles this has broken
Konbini and Bank Transfer payment methods.

This is because in ActiveMerchant we only handle tokens and credit
card payment details.

@shioyama I understand now why you would like the `payment_details` key
to handle both `tok_` and `cus_` prefixed tokens as we wouldn't need to add this hack.