### PR TITLE
Fix bank transfer payments

### DIFF
--- a/app/models/spree/bank_transfer.rb
+++ b/app/models/spree/bank_transfer.rb
@@ -22,5 +22,9 @@ module Spree
     def instructions_partial_path
       "spree/orders/bank_transfer"
     end
+
+    def imported
+      false
+    end
   end
 end

--- a/app/models/spree/gateway/komoju_bank_transfer.rb
+++ b/app/models/spree/gateway/komoju_bank_transfer.rb
@@ -18,7 +18,7 @@ module Spree
         expires_at:  response.params["payment_deadline"].to_time,
         order_id:    response.params["payment_details"]["order_id"],
         bank_number: response.params["payment_details"]["bank_number"],
-        instructions_url:    response.params["payment_details"]["instructions_url"]
+        instructions_url: response.params["payment_details"]["instructions_url"]
       ) if response.success?
       response
     end

--- a/app/models/spree/gateway/komoju_bank_transfer.rb
+++ b/app/models/spree/gateway/komoju_bank_transfer.rb
@@ -17,8 +17,9 @@ module Spree
       source.update!(
         expires_at:  response.params["payment_deadline"].to_time,
         order_id:    response.params["payment_details"]["order_id"],
-        bank_number: response.params["payment_details"]["bank_number"]
-      )
+        bank_number: response.params["payment_details"]["bank_number"],
+        instructions_url:    response.params["payment_details"]["instructions_url"]
+      ) if response.success?
       response
     end
   end

--- a/app/views/spree/orders/_bank_transfer.html.erb
+++ b/app/views/spree/orders/_bank_transfer.html.erb
@@ -1,10 +1,18 @@
 <div>
-  Thank you for your order. Instructions have been sent to your e-mail address.<br>
+  <p>
+    Thank you for your order. Instructions have been sent to your e-mail address.<br/>
+    You can find a link with instructions on how to pay below:
+  </p>
+
+  <%= link_to source.instructions_url do %>
+    How to make a bank transfer payment
+  <% end %>
+</div>
 <br>
-  <h4>Banktransfer ID: <%= source.order_id %></h4>
-  The Banktransfer ID is very important! Please make a note of it and bring it with you when you go to pay at the ATM.<br>
-  If you have chosen to use bank transfer payment, please use a bank transfer form which your bank offers, or please remit at ATM.<br>
-<br>
-  Please make sure to include your banktransfer ID in the payer's name. Please enter your banktransfer ID shown in this email in front of your name as Payer when remitting.<br>
-  Please see the confirmation email for further payment instructions.
+
+<div class='alert alert-info' role='alert'>
+  <h4>Order ID</h4>
+  <p><%= source.order_id %></p>
+  <h4>End Date</h4>
+  <p><%= source.expires_at %></p>
 </div>

--- a/db/migrate/20151207084412_add_spree_bank_transfers_instruction_url.rb
+++ b/db/migrate/20151207084412_add_spree_bank_transfers_instruction_url.rb
@@ -1,0 +1,5 @@
+class AddSpreeBankTransfersInstructionUrl < ActiveRecord::Migration
+  def change
+    add_column :spree_bank_transfers, :instructions_url, :string
+  end
+end

--- a/spec/models/spree/gateway/komoju_bank_transfer_spec.rb
+++ b/spec/models/spree/gateway/komoju_bank_transfer_spec.rb
@@ -5,6 +5,7 @@ describe Spree::Gateway::KomojuBankTransfer, type: :model do
 
   describe "#authorize" do
     let(:money) { 1000.0 }
+    let(:currency) { "JPY" }
     let(:source) do
       Spree::BankTransfer.create!(
         email: "email",
@@ -14,8 +15,7 @@ describe Spree::Gateway::KomojuBankTransfer, type: :model do
         family_name_kana: "family_name_kana"
       )
     end
-    let(:options) { { login: "api_key", shipping: 100.0, tax: 200.0, subtotal: 800.0, discount: 100.0,
-                      currency: currency } }
+    let(:options) { { login: "api_key", shipping: 100.0, tax: 200.0, subtotal: 800.0, discount: 100.0, currency: currency } }
     let(:details) do
       {
         type: "bank_transfer",
@@ -27,32 +27,64 @@ describe Spree::Gateway::KomojuBankTransfer, type: :model do
         family_name_kana: "family_name_kana"
       }
     end
-    let(:params) { { "payment_deadline" => Time.now.iso8601.to_s, "payment_details" => { "order_id" => "order_id", "bank_transfer" => "bank_transfer" } } }
-    let(:response) { double(ActiveMerchant::Billing::Response, params: params) }
+
+    let(:params) do
+      {
+        "payment_deadline" => Time.now.iso8601.to_s,
+        "payment_details" => {
+          "order_id" => "order_id",
+          "bank_number" => "bank_number",
+          "instructions_url" => "instructions_url"
+        }
+      }
+    end
 
     before do
       allow_any_instance_of(Spree::Gateway::KomojuBankTransfer).to receive(:options) { options }
     end
 
-    context "with currency is USD" do
-      let(:currency) { "USD" }
+    context 'when response is successful' do
+      let(:response) { double(ActiveMerchant::Billing::Response, params: params, success?: true) }
 
-      it "calls ActiveMerchant::Billing::KomojuGateway#purchase with original options" do
-        expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase).with(800.0, details, options) { response }
+      context 'when currency is JPY' do
+        let(:currency) { "JPY" }
 
-        subject.authorize(money, source, options)
+        it 'updates the source payment' do
+          expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase) { response }
+
+          subject.authorize(money, source, options)
+          expect(source.order_id).to eq("order_id")
+          expect(source.instructions_url).to eq("instructions_url")
+          expect(source.bank_number).to eq("bank_number")
+        end
+
+        it "creates a payment with correct active merchant options" do
+          options_converted_to_dollars = { login: "api_key", shipping: 1.0, tax: 2.0, subtotal: 8.0, discount: 1.0, currency: currency }
+          expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase).with(998.0, details, options_converted_to_dollars) { response }
+
+          subject.authorize(money, source, options)
+        end
+      end
+
+      context "when currency is USD" do
+        let(:currency) { "USD" }
+
+        it "creates a payment with correct active merchant options" do
+          expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase).with(800.0, details, options) { response }
+
+          subject.authorize(money, source, options)
+        end
       end
     end
 
-    context "with currency is JPY" do
+    context 'when response is not successful' do
+      let(:response) { double(ActiveMerchant::Billing::Response, params: params, success?: false) }
       let(:currency) { "JPY" }
 
-      it "calls ActiveMerchant::Billing::KomojuGateway#purchase with options converted from cents to dollars" do
-        options_converted_to_dollars = { login: "api_key", shipping: 1.0, tax: 2.0, subtotal: 8.0, discount: 1.0,
-                                         currency: currency }
-        expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase).with(998.0, details, options_converted_to_dollars) { response }
-
+      it 'does not update the source' do
+        expect_any_instance_of(ActiveMerchant::Billing::KomojuGateway).to receive(:purchase) { response }
         subject.authorize(money, source, options)
+        expect(source.instructions_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
Currently Bank Transfer payment do not work. I've needed to add a migration
to add the `instructions_url` for the payment. Additionally, the `BankTransfer` class was
missing an `#imported` method which is required by Spree. 