### PR TITLE
Add callback controller

### DIFF
--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -1,0 +1,34 @@
+module Spree
+  class KomojuController < ApplicationController
+    protect_from_forgery except: :callback
+
+    def callback
+      return head :unauthorized unless callback_verified?
+
+      case params[:type]
+      when "ping"
+        # do nothing
+      when "payment.captured"
+        order_number = extract_payment_number(params[:data][:external_order_num])
+        payment = Spree::Payment.find_by_number!(order_number)
+        payment.complete!
+      else
+        return head :unauthorized
+      end
+
+      head 200
+    end
+
+    private
+
+    def extract_payment_number(external_order_num)
+      external_order_num.split('-').try(:last)
+    end
+
+    def callback_verified?
+      request_body = request.body.read
+      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), SpreeKomoju.komoju_webhook_secret_token.to_s, request_body)
+      Rack::Utils.secure_compare(signature, request.env["HTTP_X_KOMOJU_SIGNATURE"].to_s)
+    end
+  end
+end

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -11,7 +11,7 @@ module Spree
       when "payment.captured"
         order_number = extract_payment_number(params[:data][:external_order_num])
         payment = Spree::Payment.find_by_number!(order_number)
-        payment.complete!
+        payment.complete! unless payment.completed?
       else
         return head :unauthorized
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
 Spree::Core::Engine.routes.draw do
+  post "komoju/callback" => "komoju#callback"
 end

--- a/lib/spree_komoju/engine.rb
+++ b/lib/spree_komoju/engine.rb
@@ -1,5 +1,6 @@
 module SpreeKomoju
   mattr_accessor :enable_customer_profiles
+  mattr_accessor :komoju_webhook_secret_token
 
   class Engine < Rails::Engine
     require 'spree/core'

--- a/spec/controllers/spree/komoju_controller_spec.rb
+++ b/spec/controllers/spree/komoju_controller_spec.rb
@@ -19,24 +19,40 @@ describe Spree::KomojuController, type: :controller do
       end
 
       context 'when type is payment.captured' do
-        let(:payment) { double Spree::Payment, complete!: true }
+        let(:payment) { double Spree::Payment, complete!: true, completed?: completed }
         let(:capture_params) do
           {
             "type" => "payment.captured",
             "data" => {
-              "external_order_num" => "SPREEORDER-PAYMENTID"
+              "external_order_num" => "SPREEORDER-PAYMENTID",
             }
           }
         end
 
         context 'when payment exists' do
-          it 'marks a payment as complete' do
-            allow(Spree::Payment).to receive(:find_by_number!) { payment }
+          context 'when payment has already been completed' do
+            let(:completed) { true }
 
-            post :callback, capture_params
+            it 'does nothing' do
+              allow(Spree::Payment).to receive(:find_by_number!) { payment }
 
-            expect(payment).to have_received(:complete!)
-          end 
+              post :callback, capture_params
+
+              expect(payment).to_not have_received(:complete!)
+            end 
+          end
+
+          context 'when payment has not been completed yet' do
+            let(:completed) { false }
+
+            it 'marks a payment as complete' do
+              allow(Spree::Payment).to receive(:find_by_number!) { payment }
+
+              post :callback, capture_params
+
+              expect(payment).to have_received(:complete!)
+            end 
+          end
         end
 
         context 'when payment doesnt exist' do

--- a/spec/controllers/spree/komoju_controller_spec.rb
+++ b/spec/controllers/spree/komoju_controller_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+describe Spree::KomojuController, type: :controller do
+  routes { Spree::Core::Engine.routes }
+
+  describe "#callback" do
+    context 'when callback is verified' do
+      before do
+        allow(OpenSSL::HMAC).to receive(:hexdigest) { "signature" }
+        request.env["HTTP_X_KOMOJU_SIGNATURE"] = "signature"
+      end
+
+      context 'when type is ping' do
+        it 'returns a successful response' do
+          post :callback, {type: "ping"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'when type is payment.captured' do
+        let(:payment) { double Spree::Payment, complete!: true }
+        let(:capture_params) do
+          {
+            "type" => "payment.captured",
+            "data" => {
+              "external_order_num" => "SPREEORDER-PAYMENTID"
+            }
+          }
+        end
+
+        context 'when payment exists' do
+          it 'marks a payment as complete' do
+            allow(Spree::Payment).to receive(:find_by_number!) { payment }
+
+            post :callback, capture_params
+
+            expect(payment).to have_received(:complete!)
+          end 
+        end
+
+        context 'when payment doesnt exist' do
+          it 'raises an activerecord error' do
+            expect {
+              post :callback, capture_params
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end    
+        end
+      end
+
+      context 'when type is not recognized' do
+        it 'returns an unauthorized status code' do
+          post :callback, {type: "bad_type"} 
+          expect(response.status).to eq(401)
+        end 
+      end
+    end  
+
+    context 'when callback is unverified' do
+      it 'returns head unauthorized' do
+        post :callback
+        expect(response.status).to eq(401)
+      end 
+    end
+  end
+end


### PR DESCRIPTION
I've added a controller to receive webhooks from Komoju. I'm using the `Spree::Payment#complete!` to mark a payment as complete which seems to work.

Spree users will need to additionally setup the following configuration
variable to set their webhook secret (otherwise it will default to empty string)

```
SpreeKomoju.komoju_webhook_secret_token = 'SECRET TOKEN'
```