### PR TITLE
Disable customer profiles for alternative payment methods

### DIFF
--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -37,5 +37,9 @@ module Spree
         end
       end
     end
+
+    def payment_profiles_supported?
+      true
+    end
   end
 end

--- a/app/models/spree/komoju_gateway.rb
+++ b/app/models/spree/komoju_gateway.rb
@@ -15,15 +15,11 @@ module Spree
     end
 
     def payment_profiles_supported?
-      true
+      false
     end
 
     def supports?(source)
       true
-    end
-
-    # no-op, override where necessary
-    def create_profile(payment)
     end
 
     # We need to change shipping, tax, subtotal and discount from cents to dollar for Komoju gateway.

--- a/db/migrate/20151126050103_add_gateway_profile_ids_to_spree_konbinis.rb
+++ b/db/migrate/20151126050103_add_gateway_profile_ids_to_spree_konbinis.rb
@@ -1,6 +1,0 @@
-class AddGatewayProfileIdsToSpreeKonbinis < ActiveRecord::Migration
-  def change
-    add_column :spree_konbinis, :gateway_customer_profile_id, :string
-    add_column :spree_konbinis, :gateway_payment_profile_id, :string
-  end
-end


### PR DESCRIPTION
We don't really need to store alternative payment methods permenantly.
Most of our payment methods can use the billing information to complete
requests.