### PR TITLE
Redefine reusable_sources on all alternative gateways

### DIFF
--- a/app/models/spree/gateway/komoju_bank_transfer.rb
+++ b/app/models/spree/gateway/komoju_bank_transfer.rb
@@ -22,5 +22,9 @@ module Spree
       ) if response.success?
       response
     end
+
+    def reusable_sources(*args)
+      []
+    end
   end
 end

--- a/app/models/spree/gateway/komoju_konbini.rb
+++ b/app/models/spree/gateway/komoju_konbini.rb
@@ -19,5 +19,9 @@ module Spree
       ) if response.success?
       response
     end
+
+    def reusable_sources(*args)
+      []
+    end
   end
 end

--- a/app/models/spree/gateway/komoju_web_money.rb
+++ b/app/models/spree/gateway/komoju_web_money.rb
@@ -33,6 +33,10 @@ module Spree
       response
     end
 
+    def reusable_sources(*args)
+      []
+    end
+
     private
 
     def multi_card_response(response)


### PR DESCRIPTION
This seems to be required and also Spree [recommends overriding it](https://github.com/spree/spree/blob/2f7322cdd764fd84bcb802eb157ad55118ff7ea0/core/app/models/spree/payment_method.rb#L54) for custom gateways.