### PR TITLE
Localize konbini order complete page

### DIFF
--- a/app/models/spree/konbini.rb
+++ b/app/models/spree/konbini.rb
@@ -19,5 +19,9 @@ module Spree
     def imported
       false
     end
+
+    def two_codes?
+      %w[lawson family-mart ministop].include?(convenience)
+    end
   end
 end

--- a/app/views/spree/orders/_konbini.html.erb
+++ b/app/views/spree/orders/_konbini.html.erb
@@ -2,7 +2,7 @@
 <% receipt_number = Spree.t("konbini_receipt_number.#{source.convenience}") %>
 <div>
   <%= Spree.t(:konbini_thanks) %><br>
-  <%= Spree.t(:konbini_instructions, convenience: store_name, receipt_number: receipt_number) %><br>
+  <%= Spree.t("konbini_instructions.#{source.convenience}", receipt_number: receipt_number) %><br>
   <br>
   <%= link_to source.instructions_url do %>
     <%= Spree.t(:konbini_how_to_pay, convenience: store_name) %>

--- a/app/views/spree/orders/_konbini.html.erb
+++ b/app/views/spree/orders/_konbini.html.erb
@@ -1,17 +1,16 @@
+<% store_name = Spree.t("conveniences.#{source.convenience}") %>
+<% receipt_number = Spree.t("konbini_receipt_number.#{source.convenience}") %>
 <div>
-  Thank you for your order. Instructions have been sent to your e-mail address.<br>
-  To complete a payment at <%= source.convenience.camelcase %>, Receipt Number and Confirmation Number are required.<br>
+  <%= Spree.t(:konbini_thanks) %><br>
+  <%= Spree.t(:konbini_instructions, convenience: store_name, receipt_number: receipt_number) %><br>
   <br>
   <%= link_to source.instructions_url do %>
-    How to make a payment at <%= source.convenience.camelcase %>
+    <%= Spree.t(:konbini_how_to_pay, convenience: store_name) %>
   <% end %>
 </div>
 <br>
-<div class='alert alert-info' role='alert'>
-  <h4>Receipt Number</h4>
-  <p><%= source.receipt %></p>
-  <h4>Confirmation Number</h4>
-  <p><%= source.confirmation_code %></p>
-  <h4>End Date</h4>
-  <p><%= source.expires_at %></p>
-</div>
+<table class="table table-condensed table-bordered">
+<tr class="info"><td><%= receipt_number %></td><td><strong><%= source.receipt %></strong></td></tr>
+<tr class="info"J><td><%= Spree.t(:konbini_confirmation_number) %></td><td><strong><%= source.confirmation_code %></strong></td></tr>
+<tr class="info"><td><%= Spree.t(:konbini_end_date) %></td><td><strong><%= source.expires_at %></strong></td></tr>
+</table>

--- a/app/views/spree/orders/_konbini.html.erb
+++ b/app/views/spree/orders/_konbini.html.erb
@@ -11,6 +11,8 @@
 <br>
 <table class="table table-condensed table-bordered">
 <tr class="info"><td><%= receipt_number %></td><td><strong><%= source.receipt %></strong></td></tr>
-<tr class="info"J><td><%= Spree.t(:konbini_confirmation_number) %></td><td><strong><%= source.confirmation_code %></strong></td></tr>
+<% if source.two_codes? %>
+  <tr class="info"J><td><%= Spree.t(:konbini_confirmation_number) %></td><td><strong><%= source.confirmation_code %></strong></td></tr>
+<% end %>
 <tr class="info"><td><%= Spree.t(:konbini_end_date) %></td><td><strong><%= source.expires_at %></strong></td></tr>
 </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,17 +19,28 @@ en:
     family_name_kana: Last Name (Katakana)
     prepaid_number: Prepaid Number
     konbini_receipt_number:
-      circle_k: Receipt Number
-      daily_yamazaki: Receipt Number
-      family_mart: Receipt Number
+      circle-k: Receipt Number
+      daily-yamazaki: Receipt Number
+      family-mart: Receipt Number
       lawson: Receipt Number
       ministop: Receipt Number
-      seven_eleven: Receipt Number
+      seven-eleven: Receipt Number
       sunkus: Receipt Number
     konbini_confirmation_number: Confirmation Number
     konbini_end_date: End Date
     konbini_thanks: Thank you for your order. Instructions have been sent to your e-mail address.
-    konbini_instructions: To complete your payment at %{convenience}, your %{receipt_number} and confirmation number are required.
+    konbini_instructions:
+      one_code: &komoju-konbini-instructions-one-code
+        To complete your payment, your %{receipt_number} is required.
+      two_codes: &komoju-konbini-instructions-two-codes
+        To complete your payment, your %{receipt_number} and confirmation number are required.
+      lawson: *komoju-konbini-instructions-two-codes
+      family-mart: *komoju-konbini-instructions-two-codes
+      mini-stop: *komoju-konbini-instructions-two-codes
+      sunkus: *komoju-konbini-instructions-one-code
+      circle-k: *komoju-konbini-instructions-one-code
+      daily-yamazaki: *komoju-konbini-instructions-one-code
+      seven-eleven: *komoju-konbini-instructions-one-code
     konbini_how_to_pay: How to make a payment at %{convenience}
     komoju:
       attributes: &komoju-payment-details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,13 +19,13 @@ en:
     family_name_kana: Last Name (Katakana)
     prepaid_number: Prepaid Number
     konbini_receipt_number:
-      circle_k: Online Payment Number
-      daily_yamazaki: Online Payment Number
+      circle_k: Receipt Number
+      daily_yamazaki: Receipt Number
       family_mart: Receipt Number
       lawson: Receipt Number
       ministop: Receipt Number
-      seven_eleven: Online Receipt Number
-      sunkus: Online Payment Number
+      seven_eleven: Receipt Number
+      sunkus: Receipt Number
     konbini_confirmation_number: Confirmation Number
     konbini_end_date: End Date
     konbini_thanks: Thank you for your order. Instructions have been sent to your e-mail address.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,19 @@ en:
     given_name_kana: First Name (Katakana)
     family_name_kana: Last Name (Katakana)
     prepaid_number: Prepaid Number
+    konbini_receipt_number:
+      circle_k: Online Payment Number
+      daily_yamazaki: Online Payment Number
+      family_mart: Receipt Number
+      lawson: Receipt Number
+      ministop: Receipt Number
+      seven_eleven: Online Receipt Number
+      sunkus: Online Payment Number
+    konbini_confirmation_number: Confirmation Number
+    konbini_end_date: End Date
+    konbini_thanks: Thank you for your order. Instructions have been sent to your e-mail address.
+    konbini_instructions: To complete your payment at %{convenience}, your %{receipt_number} and confirmation number are required.
+    konbini_how_to_pay: How to make a payment at %{convenience}
     komoju:
       attributes: &komoju-payment-details
         email: Email

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,13 +15,13 @@ ja:
     family_name: 姓
     given_name_kana: 名 (カタカナ)
     konbini_receipt_number:
-      circle_k: "オンライン決済番号"
-      daily_yamazaki: "オンライン決済番号"
-      family_mart: "お支払い受付番号"
-      lawson: "受付番号"
-      ministop: "受付番号"
-      seven_eleven: "オンライン受付番号"
-      sunkus: "オンライン決済番号"
+      circle_k: オンライン決済番号
+      daily_yamazaki: オンライン決済番号
+      family_mart: お客様番号
+      lawson: お客様番号
+      ministop: お客様番号
+      seven_eleven: 払込票番号
+      sunkus: オンライン決済番号
     konbini_confirmation_number: 確認番号
     konbini_end_date: お支払い期限
     konbini_thanks: "ご注文ありがとうございました。お支払い内容については、メールでもお送りしていますのでご確認ください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,17 +16,28 @@ ja:
     given_name_kana: 名 (カタカナ)
     family_name_kana: 姓 (カタカナ)
     konbini_receipt_number:
-      circle_k: オンライン決済番号
-      daily_yamazaki: オンライン決済番号
-      family_mart: お客様番号
+      circle-k: オンライン決済番号
+      daily-yamazaki: オンライン決済番号
+      family-mart: お客様番号
       lawson: お客様番号
       ministop: お客様番号
-      seven_eleven: 払込票番号
+      seven-eleven: 払込票番号
       sunkus: オンライン決済番号
     konbini_confirmation_number: 確認番号
     konbini_end_date: お支払い期限
     konbini_thanks: "ご注文ありがとうございました。お支払い内容については、メールでもお送りしていますのでご確認ください。"
-    konbini_instructions: "コンビニ決済には『確認番号』と『%{receipt_number}』が必要です。"
+    konbini_instructions:
+      one_code: &komoju-konbini-instructions-one-code
+        "コンビニ決済には『%{receipt_number}』が必要です。"
+      two_codes: &komoju-konbini-instructions-two-codes
+        "コンビニ決済には『確認番号』と『%{receipt_number}』が必要です。"
+      lawson: *komoju-konbini-instructions-two-codes
+      family-mart: *komoju-konbini-instructions-two-codes
+      mini-stop: *komoju-konbini-instructions-two-codes
+      sunkus: *komoju-konbini-instructions-one-code
+      circle-k: *komoju-konbini-instructions-one-code
+      daily-yamazaki: *komoju-konbini-instructions-one-code
+      seven-eleven: *komoju-konbini-instructions-one-code
     konbini_how_to_pay: "%{convenience}の支払方法"
     komoju:
       attributes: &komoju-payment-details

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,7 @@ ja:
     given_name: 名
     family_name: 姓
     given_name_kana: 名 (カタカナ)
+    family_name_kana: 姓 (カタカナ)
     konbini_receipt_number:
       circle_k: オンライン決済番号
       daily_yamazaki: オンライン決済番号
@@ -27,11 +28,27 @@ ja:
     konbini_thanks: "ご注文ありがとうございました。お支払い内容については、メールでもお送りしていますのでご確認ください。"
     konbini_instructions: "コンビニ決済には『確認番号』と『%{receipt_number}』が必要です。"
     konbini_how_to_pay: "%{convenience}の支払方法"
-    family_name_kana: 姓 (カタカナ)
-  activerecord:
-    attributes:
-      spree/pay_easy:
-        given_name_kana: 名 (カタカナ)
-        family_name_kana: 姓 (カタカナ)
+    komoju:
+      attributes: &komoju-payment-details
+        email: メール
+        phone: 電話番号
+        given_name_kana: フリガナ(名)
+        family_name_kana: フリガナ(姓)
         given_name: 名
         family_name: 姓
+        instructions_url: "支払方法ページへの URL"
+        prepaid_number: プリペイド番号
+        order_id: 振込番号
+        expires: 有効期限
+        bank_id: "PayEasy支払い時に必要となるお客様番号"
+        customer_id: "PayEasy支払い時に必要となるお客様番号"
+        confirmation_id: "PayEasy支払い時に必要となるお客様番号"
+      web_money:
+        balance_remaining: 不足額
+        points: ポイント
+        insufficient_funds: "残高不足です"
+  activerecord:
+    attributes:
+      spree/pay_easy: *komoju-payment-details
+      spree/web_money: *komoju-payment-details
+      spree/bank_transfer: *komoju-payment-details

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,19 @@ ja:
     given_name: 名
     family_name: 姓
     given_name_kana: 名 (カタカナ)
+    konbini_receipt_number:
+      circle_k: "オンライン決済番号"
+      daily_yamazaki: "オンライン決済番号"
+      family_mart: "お支払い受付番号"
+      lawson: "受付番号"
+      ministop: "受付番号"
+      seven_eleven: "オンライン受付番号"
+      sunkus: "オンライン決済番号"
+    konbini_confirmation_number: 確認番号
+    konbini_end_date: お支払い期限
+    konbini_thanks: "ご注文ありがとうございました。お支払い内容については、メールでもお送りしていますのでご確認ください。"
+    konbini_instructions: "コンビニ決済には『確認番号』と『%{receipt_number}』が必要です。"
+    konbini_how_to_pay: "%{convenience}の支払方法"
     family_name_kana: 姓 (カタカナ)
   activerecord:
     attributes:


### PR DESCRIPTION
Looks like this:

![latest-screenshot](https://cloud.githubusercontent.com/assets/561827/11865537/065c3d82-a4e8-11e5-866f-21584f04c3d3.png)

`Order Number` is coming up instead of the order number for me, but maybe that's a Spree thing. Maybe too heavily formatted, just wanted something that looked reasonable and was localized.