### PR TITLE
Add void + cancel methods and enable partial refunds

### DIFF
--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -9,6 +9,14 @@ module Spree
       provider.refund(money, response_code, {})
     end
 
+    def cancel(response_code)
+      provider.void(response_code)
+    end
+
+    def void(response_code, source, gateway_options)
+      provider.void(response_code)
+    end
+
     def purchase(money, source, options)
       options = change_options_to_dollar(options) if options[:currency] == "JPY"
       if profile_id = source.gateway_payment_profile_id || source.gateway_customer_profile_id

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -44,7 +44,6 @@ module ActiveMerchant #:nodoc:
 
       def refund(amount, identification, options = {})
         params = { :amount => amount }
-        params[:description] = options[:refund_message] if options[:refund_message].present?
         commit("/payments/#{identification}/refund", params)
       end
 

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -42,7 +42,13 @@ module ActiveMerchant #:nodoc:
         commit("/payments", post)
       end
 
-      def refund(money, identification, options = {})
+      def refund(amount, identification, options = {})
+        params = { :amount => amount }
+        params[:description] = options[:refund_message] if options[:refund_message].present?
+        commit("/payments/#{identification}/refund", params)
+      end
+
+      def void(identification, options = {})
         commit("/payments/#{identification}/refund", {})
       end
 

--- a/spec/models/spree/gateway/komoju_credit_card_spec.rb
+++ b/spec/models/spree/gateway/komoju_credit_card_spec.rb
@@ -67,6 +67,25 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
     end
   end
 
+  describe "#void" do
+    let(:response_code) { "external_payment_id" }
+    let(:source) { double("credit card") }
+
+    it "voids payment" do
+      expect(komoju_gateway).to receive(:void).with(response_code)
+      subject.void(response_code, source, {})
+    end
+  end
+
+  describe "#cancel" do
+    let(:response_code) { "external_payment_id" }
+
+    it "voids payment" do
+      expect(komoju_gateway).to receive(:void).with(response_code)
+      subject.void(response_code, double("source"), {})
+    end
+  end
+
   describe "#create_profile" do
     let(:payment) { double("payment", source: source) }
     let(:details) { double("payment details") }


### PR DESCRIPTION
Fixes #37

This adds cancel/void methods for credit card payments and also updates the AM gateway to actually send the amount to be refunded (otherwise it will always perform a full refund).

We are moving further away from the code on AM, we will have to make another PR there to sync up.