### PR TITLE
Add localized e-mail support

### DIFF
--- a/app/models/spree/komoju_gateway.rb
+++ b/app/models/spree/komoju_gateway.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def options
-      super.merge(login: preferred_api_key, test: preferred_test_mode)
+      super.merge(login: preferred_api_key, test: preferred_test_mode, locale: locale)
     end
 
     def auto_capture?
@@ -42,6 +42,12 @@ module Spree
 
     def payment_source_class
       "Spree::#{gateway_type.camelcase}".constantize
+    end
+
+    private
+
+    def locale
+      I18n.locale == :ja ? "ja" : "en"
     end
   end
 end

--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options = {})
         post = {}
         post[:amount] = amount(money)
+        post[:locale] = @options[:locale] if @options[:locale]
         post[:description] = options[:description]
         add_payment_details(post, payment, options)
         post[:currency] = options[:currency] || default_currency

--- a/spec/models/spree/komoju_gateway_spec.rb
+++ b/spec/models/spree/komoju_gateway_spec.rb
@@ -13,7 +13,7 @@ describe Spree::KomojuGateway, type: :model do
       allow(subject).to receive(:preferred_api_key) { api_key }
       allow(subject).to receive(:preferred_test) { true }
 
-      expect(subject.options).to eq ({ api_key: nil, test: true, server: "test", test_mode: true, login: api_key })
+      expect(subject.options).to eq ({ api_key: nil, test: true, server: "test", test_mode: true, login: api_key, locale: "en" })
     end
   end
 


### PR DESCRIPTION
We need to pass a `locale` parameter along with the request
so Komoju can figure out which e-mail locale to use.