### PR TITLE
Select first Konbini option by default

### DIFF
--- a/app/views/spree/checkout/payment/_komoju_konbini.html.erb
+++ b/app/views/spree/checkout/payment/_komoju_konbini.html.erb
@@ -1,9 +1,9 @@
 <div class="well clearfix">
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
-  <% Spree::Konbini::STORES.each do |store| %>
+  <% Spree::Konbini::STORES.each_with_index do |store, index| %>
     <label>
-      <%= radio_button "#{param_prefix}", "convenience", store %>
+      <%= radio_button "#{param_prefix}", "convenience", store, checked: index.zero? %>
       <%= image_tag "#{store}.png" %>
       <span><%= Spree.t("conveniences.#{store}") %></span>
     </label><br />


### PR DESCRIPTION
If a customer tries to make a payment without selecting a Konbini
they get a vague error message saying the payment couldn't be created.

As a quick fix, we can select a konbini by default to prevent
customers from getting confused.

![image](https://cloud.githubusercontent.com/assets/82835/13594920/0b61626e-e54b-11e5-8fa0-cfc2e4896fe9.png)
