### PR TITLE
Remove cents_to_dollar method

### DIFF
--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -5,7 +5,6 @@ module Spree
     end
 
     def credit(money, source, response_code, gateway_options)
-      money = cents_to_dollar(money) if gateway_options[:currency] == "JPY"
       provider.refund(money, response_code, {})
     end
 
@@ -53,12 +52,6 @@ module Spree
 
     def payment_profiles_supported?
       true
-    end
-
-    private
-
-    def cents_to_dollar(amount)
-      amount / 100.0
     end
   end
 end

--- a/app/models/spree/gateway/komoju_credit_card.rb
+++ b/app/models/spree/gateway/komoju_credit_card.rb
@@ -4,7 +4,7 @@ module Spree
       true
     end
 
-    def credit(money, source, response_code, gateway_options)
+    def credit(money, source, response_code, refund_options)
       provider.refund(money, response_code, {})
     end
 

--- a/spec/models/spree/gateway/komoju_credit_card_spec.rb
+++ b/spec/models/spree/gateway/komoju_credit_card_spec.rb
@@ -58,13 +58,6 @@ describe Spree::Gateway::KomojuCreditCard, type: :model do
       expect(komoju_gateway).to receive(:refund).with(cent_amount, response_code, {})
       subject.credit(cent_amount, source, response_code, {})
     end
-
-    context "when currency is JPY" do
-      it "receives dollar amount" do
-        expect(komoju_gateway).to receive(:refund).with(100.0, response_code, {})
-        subject.credit(cent_amount, source, response_code, {currency: "JPY"})
-      end
-    end
   end
 
   describe "#void" do


### PR DESCRIPTION
The `credit` method's third argument is not Hash for gateway options.
Currency is nil everytime now.

That's "Hash" but included Refund instance.
https://github.com/spree/spree/blob/master/core/app/models/spree/refund.rb#L58-L60