### PR TITLE
Always return a 200 status code regardless of the type

### DIFF
--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -6,14 +6,10 @@ module Spree
       return head :unauthorized unless callback_verified?
 
       case params[:type]
-      when "ping"
-        # do nothing
       when "payment.captured"
         order_number = extract_payment_number(params[:data][:external_order_num])
         payment = Spree::Payment.find_by_number!(order_number)
         payment.complete! unless payment.completed?
-      else
-        return head :unauthorized
       end
 
       head 200

--- a/spec/controllers/spree/komoju_controller_spec.rb
+++ b/spec/controllers/spree/komoju_controller_spec.rb
@@ -65,9 +65,9 @@ describe Spree::KomojuController, type: :controller do
       end
 
       context 'when type is not recognized' do
-        it 'returns an unauthorized status code' do
+        it 'returns an 200 status code' do
           post :callback, {type: "bad_type"} 
-          expect(response.status).to eq(401)
+          expect(response.status).to eq(200)
         end 
       end
     end  


### PR DESCRIPTION
Komoju will keep sending webhooks until it receives a 200 OK response.
When events like "payment.updated" or "ping" are sent we should always return 200 regardless of the event type otherwise Komoju will keep re-sending the webhook until its successfull.