### PR TITLE
Handle refunded callback

### DIFF
--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -7,15 +7,36 @@ module Spree
 
       case params[:type]
       when "payment.captured"
-        order_number = extract_payment_number(params[:data][:external_order_num])
-        payment = Spree::Payment.find_by_number!(order_number)
-        payment.complete! unless payment.completed?
+        payment_captured!
+      when "payment.refunded"
+        payment_refunded!
       end
 
       head 200
     end
 
     private
+
+    def order_number
+      extract_payment_number(params[:data][:external_order_num])
+    end
+
+    def payment
+      @payment ||= Spree::Payment.find_by_number!(order_number)
+    end
+
+    def payment_captured!
+      payment.complete! unless payment.completed?
+    end
+
+    def payment_refunded!
+      if payment.completed?
+        refund = params[:data][:refunds].last
+        description = refund[:description].blank? ? "Komoju refund" : refund[:description]
+        reason = Spree::RefundReason.new(name: description)
+        payment.refunds.create!(amount: payment.amount, reason: reason, transaction_id: refund[:id])
+      end
+    end
 
     def extract_payment_number(external_order_num)
       external_order_num.split('-').try(:last)

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -18,11 +18,19 @@ module Spree
     private
 
     def order_number
-      extract_payment_number(params[:data][:external_order_num])
+      params[:data][:external_order_num].split("-").try(:first)
+    end
+
+    def payment_number
+      params[:data][:external_order_num].split("-").try(:last)
+    end
+
+    def order
+      @order ||= Spree::Order.find_by_number!(order_number)
     end
 
     def payment
-      @payment ||= Spree::Payment.find_by_number!(order_number)
+      @payment ||= order.payments.find_by_number!(payment_number)
     end
 
     def payment_captured!
@@ -36,10 +44,6 @@ module Spree
         reason = Spree::RefundReason.new(name: description)
         payment.refunds.create!(amount: payment.amount, reason: reason, transaction_id: refund[:id])
       end
-    end
-
-    def extract_payment_number(external_order_num)
-      external_order_num.split('-').try(:last)
     end
 
     def callback_verified?

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -41,7 +41,7 @@ module Spree
       if payment.completed?
         refund = params[:data][:refunds].last
         description = refund[:description].blank? ? "Komoju refund" : refund[:description]
-        reason = Spree::RefundReason.new(name: description)
+        reason = Spree::RefundReason.find_or_create_by!(name: description)
         payment.refunds.create!(amount: payment.amount, reason: reason, transaction_id: refund[:id])
       end
     end

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -43,6 +43,7 @@ module Spree
         description = refund[:description].blank? ? "Komoju refund" : refund[:description]
         reason = Spree::RefundReason.find_or_create_by!(name: description)
         payment.refunds.create!(amount: payment.amount, reason: reason, transaction_id: refund[:id])
+        order.updater.update
       end
     end
 

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -7,56 +7,15 @@ module Spree
 
       case params[:type]
       when "payment.captured"
-        payment_captured!
+        SpreeKomoju::Callbacks::Captured.new(params).process!
       when "payment.refunded"
-        payment_refunded!
+        SpreeKomoju::Callbacks::Refunded.new(params).process!
       end
 
       head 200
     end
 
     private
-
-    def order_number
-      params[:data][:external_order_num].split("-").try(:first)
-    end
-
-    def payment_number
-      params[:data][:external_order_num].split("-").try(:last)
-    end
-
-    def order
-      @order ||= Spree::Order.find_by_number!(order_number)
-    end
-
-    def payment
-      @payment ||= order.payments.find_by_number!(payment_number)
-    end
-
-    def payment_captured!
-      payment.complete! unless payment.completed?
-    end
-
-    def refund_params
-      params[:data][:refunds].last
-    end
-
-    def refund_description
-      refund_params[:description].blank? ? "Komoju refund" : refund_params[:description]
-    end
-
-    def refund_amount
-      # Converts cents into dollars
-      ::Money.new(refund_params[:amount], refund_params[:currency]).to_f
-    end
-
-    def payment_refunded!
-      if payment.completed? && payment.credit_allowed >= refund_amount && payment.currency == refund_params[:currency]
-        reason = Spree::RefundReason.find_or_create_by!(name: refund_description)
-        payment.refunds.create!(amount: refund_amount, reason: reason, transaction_id: refund_params[:id])
-        order.updater.update
-      end
-    end
 
     def callback_verified?
       request_body = request.body.read

--- a/app/controllers/spree/komoju_controller.rb
+++ b/app/controllers/spree/komoju_controller.rb
@@ -47,7 +47,7 @@ module Spree
 
     def refund_amount
       # Converts cents into dollars
-      ::Money.new(refund_params[:amount], "USD").to_f
+      ::Money.new(refund_params[:amount], refund_params[:currency]).to_f
     end
 
     def payment_refunded!

--- a/lib/spree_komoju.rb
+++ b/lib/spree_komoju.rb
@@ -2,6 +2,9 @@ require 'spree_core'
 require 'spree_komoju/engine'
 require 'spree_komoju/errors'
 require 'spree_komoju/controller_helpers'
+require 'spree_komoju/callbacks/callback'
+require 'spree_komoju/callbacks/captured'
+require 'spree_komoju/callbacks/refunded'
 
 # This extension adds HTTP PATCH to ssl_request.
 # This is needed for WebMoney multi-card in Komoju.

--- a/lib/spree_komoju/callbacks/callback.rb
+++ b/lib/spree_komoju/callbacks/callback.rb
@@ -1,0 +1,29 @@
+module SpreeKomoju
+  module Callbacks
+    class Callback
+      attr_reader :params
+
+      def initialize(callback_params)
+        @params = callback_params
+      end
+
+      protected
+
+      def order_number
+        params[:data][:external_order_num].split("-").try(:first)
+      end
+
+      def payment_number
+        params[:data][:external_order_num].split("-").try(:last)
+      end
+
+      def order
+        @order ||= Spree::Order.find_by_number!(order_number)
+      end
+
+      def payment
+        @payment ||= order.payments.find_by_number!(payment_number)
+      end
+    end
+  end
+end

--- a/lib/spree_komoju/callbacks/captured.rb
+++ b/lib/spree_komoju/callbacks/captured.rb
@@ -1,0 +1,9 @@
+module SpreeKomoju
+  module Callbacks
+    class Captured < Callback
+      def process!
+        payment.complete! unless payment.completed?
+      end
+    end
+  end
+end

--- a/lib/spree_komoju/callbacks/refunded.rb
+++ b/lib/spree_komoju/callbacks/refunded.rb
@@ -1,0 +1,32 @@
+module SpreeKomoju
+  module Callbacks
+    class Refunded < Callback
+      def process!
+        return unless payment.completed?
+
+        refunds.each do |refund_params|
+          process_refund!(refund_params)
+        end
+
+        order.updater.update
+      end
+
+      private
+
+      def process_refund!(refund_params)
+        raise SpreeKomoju::Errors::IncorrectCurrency.new unless refund_params[:currency] == payment.currency
+
+        refund_amount = ::Money.new(refund_params[:amount], refund_params[:currency]).to_f
+        return if refund_amount > payment.credit_allowed
+
+        refund_description = refund_params[:description].blank? ? "Komoju refund" : refund_params[:description]
+        reason = Spree::RefundReason.find_or_create_by!(name: refund_description)
+        payment.refunds.create!(amount: refund_amount, reason: reason, transaction_id: refund_params[:id])
+      end
+
+      def refunds
+        params[:data][:refunds]
+      end
+    end
+  end
+end

--- a/lib/spree_komoju/errors.rb
+++ b/lib/spree_komoju/errors.rb
@@ -1,5 +1,6 @@
 module SpreeKomoju
   module Errors
     class UnsupportedCurrency < StandardError; end
+    class IncorrectCurrency < StandardError; end
   end
 end

--- a/spec/controllers/spree/komoju_controller_spec.rb
+++ b/spec/controllers/spree/komoju_controller_spec.rb
@@ -19,7 +19,8 @@ describe Spree::KomojuController, type: :controller do
       end
 
       context 'when type is payment.refunded' do
-        let(:payment) { create :payment, state: state, number: "PAYMENTID" }
+        let(:order) { create :order, number: "SPREEORDER" }
+        let(:payment) { create :payment, order: order, state: state, number: "PAYMENTID" }
         let(:refund_description) { "Test refund" }
         let(:refund_params) do
           {
@@ -72,7 +73,7 @@ describe Spree::KomojuController, type: :controller do
             let(:completed) { true }
 
             it 'does nothing' do
-              allow(Spree::Payment).to receive(:find_by_number!) { payment }
+              allow_any_instance_of(Spree::KomojuController).to receive(:payment) { payment }
 
               post :callback, capture_params
 
@@ -84,7 +85,7 @@ describe Spree::KomojuController, type: :controller do
             let(:completed) { false }
 
             it 'marks a payment as complete' do
-              allow(Spree::Payment).to receive(:find_by_number!) { payment }
+              allow_any_instance_of(Spree::KomojuController).to receive(:payment) { payment }
 
               post :callback, capture_params
 

--- a/spec/controllers/spree/komoju_controller_spec.rb
+++ b/spec/controllers/spree/komoju_controller_spec.rb
@@ -21,14 +21,14 @@ describe Spree::KomojuController, type: :controller do
       context 'when type is payment.refunded' do
         let(:order) { create :order, number: "SPREEORDER" }
         let(:payment) { create :payment, order: order, state: state, number: "PAYMENTID" }
-        let(:refund_description) { "Test refund" }
         let(:refund_params) do
           {
             "type" => "payment.refunded",
             "data" => {
               "external_order_num" => "SPREEORDER-PAYMENTID",
               "refunds" => [{
-                "description": refund_description
+                "id": "REFUND_ID",
+                "description": "My description"
               }]
             }
           }
@@ -50,7 +50,7 @@ describe Spree::KomojuController, type: :controller do
               expect { post :callback, refund_params }.to change {payment.refunds.count}.from(0).to(1)
               refund = payment.refunds.first
               expect(refund.amount).to eq payment.amount
-              expect(refund.reason.name).to eq "Test refund"
+              expect(refund.reason.name).to eq "My description"
             end
           end
 


### PR DESCRIPTION
Delivers: #54 

The `Spree::KomojuController` handles "payment.refunded" callbacks by creating a `Spree::Refund` on the associated payment.