### PR TITLE
Use locale passed in arguments

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options = {})
         post = {}
         post[:amount] = amount(money)
-        post[:locale] = @options[:locale] if @options[:locale]
+        post[:locale] = options[:locale] if options[:locale]
         post[:description] = options[:description]
         add_payment_details(post, payment, options)
         post[:currency] = options[:currency] || default_currency


### PR DESCRIPTION
This doesn't change anything since we have an `attr_reader` in the inherited `Gateway` class, but just for consistency...